### PR TITLE
Resolve Failed to parse mapping [_default_]: _id is not configurable

### DIFF
--- a/default-mappings.json
+++ b/default-mappings.json
@@ -13,9 +13,6 @@
    },
   "mappings": {
     "_default_": {
-      "_id": {
-        "path": "id"
-      },
       "_all" : {
         "enabled" : true
       },


### PR DESCRIPTION
When the index does not exist the library tries to auto-create it. Although the default mapping has _id which is no longer configurable.